### PR TITLE
Add vicePath setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /build/
 /node_modules/
 /test/**/*.actual.asm
-/*.prg
+/examples/**/*.prg
 test/errors/*.actual_errors.txt
 /vscode/*.vsix
 /c64jasm-*.tgz

--- a/vscode/client/src/c64jasmDebug.ts
+++ b/vscode/client/src/c64jasmDebug.ts
@@ -54,6 +54,8 @@ export class C64jasmDebugSession extends LoggingDebugSession {
         stopwatch: 0
     };
 
+    private _vicePath: string;
+
     /**
      * Creates a new debug adapter that is used for one debug session.
      * We configure the default implementation of a debug adapter here.
@@ -93,6 +95,10 @@ export class C64jasmDebugSession extends LoggingDebugSession {
         this._runtime.on('end', () => {
             this.sendEvent(new TerminatedEvent());
         });
+    }
+
+    public setVicePath(vicePath: string) {
+        this._vicePath = vicePath;
     }
 
     /**
@@ -136,7 +142,7 @@ export class C64jasmDebugSession extends LoggingDebugSession {
         await this._configurationDone.wait(1000);
 
         // start the program in the runtime
-        this._runtime.start(args.program, !!args.stopOnEntry);
+        this._runtime.start(args.program, !!args.stopOnEntry, this._vicePath);
 
         this.sendResponse(response);
     }

--- a/vscode/client/src/c64jasmRuntime.ts
+++ b/vscode/client/src/c64jasmRuntime.ts
@@ -309,14 +309,14 @@ export class C64jasmRuntime extends EventEmitter {
     /**
      * Start executing the given program.
      */
-    public async start(program: string, stopOnEntry: boolean) {
+    public async start(program: string, stopOnEntry: boolean, vicePath?: string) {
         // Ask c64jasm compiler for debug information.  This is done
         // by connecting to a running c64jasm process that's watching
         // source files for changes.
         this._debugInfo = await queryC64jasmDebugInfo();
         const startAddress = parseBasicSysAddress(program);
          //# this doesn't work with vscode as it breaks into VICE monitor, not remote monitor
-        this._viceProcess = child_process.exec(`x64 -remotemonitor`);
+        this._viceProcess = child_process.exec(`${vicePath || "x64"} -remotemonitor`);
         await sleep(6000);
 
         const echoLog = (logMsg: string) => {

--- a/vscode/client/src/extension.ts
+++ b/vscode/client/src/extension.ts
@@ -79,6 +79,8 @@ class C64jasmConfigurationProvider implements vscode.DebugConfigurationProvider 
 				// start listening on a random port
 				this._server = Net.createServer(socket => {
 					const session = new C64jasmDebugSession();
+					const vicePath = vscode.workspace.getConfiguration("languageServerC64jasm")["vicePath"];
+					session.setVicePath(vicePath);
 					session.setRunAsServer(true);
 					session.start(<NodeJS.ReadableStream>socket, socket);
 				}).listen(0);

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -43,6 +43,11 @@
 					],
 					"default": "off",
 					"description": "Traces the communication between VS Code and the language server."
+				},
+				"languageServerC64jasm.vicePath": {
+					"scope": "machine",
+					"type": "string",
+					"description": "Where to find the VICE executable"
 				}
 			}
 		},
@@ -89,11 +94,11 @@
 				"path": "./syntaxes/c64jasm.tmLanguage.json"
 			}
 		],
-        "breakpoints": [
-            {
-                "language": "asm"
-            }
-        ],
+		"breakpoints": [
+			{
+				"language": "asm"
+			}
+		],
 		"debuggers": [
 			{
 				"type": "c64jasm",


### PR DESCRIPTION
git ignore .prg files under examples

--
It's not the cleanest change, but I spent ages trying to figure out a way to do it... It's complicated by the client/server thing and the debug adapter which means I couldn't add parameters to the constructors.

This is my first pull request ever, so tell me what's up. Maybe I messed up. The workflow is a bit strange... I had already cloned so I had to do some fiddling to convert to a fork.

Anyway I just thought it was a bit annoying that I had to add vice to my system path :)
