### PR TITLE
Try loading plugin by name if file not in source-tree

### DIFF
--- a/src/asm.ts
+++ b/src/asm.ts
@@ -414,7 +414,11 @@ class Assembler {
         if (p !== undefined) {
             return p;
         }
-        const newPlugin = importFresh(path.resolve(this.makeSourceRelativePath(fname)));
+
+        const pluginName = './'.indexOf(fname[0]) < 0
+          ? fname
+          : path.resolve(this.makeSourceRelativePath(fname));
+        const newPlugin = importFresh(pluginName);
         this.pluginCache.set(fname, newPlugin);
         return newPlugin;
     }

--- a/test/cases/array2.input.asm
+++ b/test/cases/array2.input.asm
@@ -1,7 +1,7 @@
 
 * = $801
 
-!use "plugin-multiple-exports" as m
+!use "./plugin-multiple-exports" as m
 
 !for s in m.nestedArray() {
     ; Iterate list elems directly


### PR DESCRIPTION
Hi!
I stumbled upon your project whilst learning more about c64 assembly dev and I really like what you've accomplished - powerful and versatile as KickAss but simple to extend and quick and easy to get going!

While I agree that keeping project specific plugins together with the source is a good idea, I still believe that some kinds of plugins (e.g sid-loading) could benefit from being packaged as separate modules, kinda like the Node stdlib. Also community developed generic modules could be supported.

Anyway, here is an initial take on how to possible support this by introducing a slight change with regards to how plugin paths are currently resolved. What do you think?

Please note that the proposed change will introduce a breaking change in the `!use` pseudo op to make it's behavior mirror that of Node's `require`. Plugins referred to with a prefix of either `.`, `./` or `/` will still be loaded directly from the file system as today, whereas "plain" names will try to load the plugin from the `node_modules` folder.

I haven't added test cases for this yet, as I would like to run this by you first and don't really have a good idea on how to ship a test plugin module for inclusion besides actually adding it to `node_modules` - but that should be solvable.

Regards,
Johan