### PR TITLE
Added CLI option to save disassembly file

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,13 +95,30 @@ function compile(args: any) {
         }
     }
 
-    if (args.disasm) {
-        const { isInstruction } = debugInfo!.info();
-        const disasm = disassemble(prg, { isInstruction });
-        for (const disasmLine of disasm) {
-            console.log(disasmLine);
+    if (args.disasm || args.disasmFile) {
+        let fd: number;
+        try{
+            console.log(`Generating ${args.disasmFile}`)
+            const { isInstruction } = debugInfo!.info();
+            const disasm = disassemble(prg, { isInstruction });
+
+            if (args.disasmFile) {
+                fd = fs.openSync(args.disasmFile, 'w');
+                for (const disasmLine of disasm) {
+                    fs.writeSync(fd, `${disasmLine}\n`);
+                }
+            } else {
+                for (const disasmLine of disasm) {
+                    console.log(disasmLine);   
+                }
+            }
+
+
+        } catch(err) {
+            console.error(err);
         }
     }
+
     return true;
 }
 
@@ -146,6 +163,10 @@ parser.addArgument('--disasm', {
     constant: true,
     dest: 'disasm',
     help: 'Disassemble the resulting binary on stdout.'
+});
+parser.addArgument('--disasm-file', {
+    dest: 'disasmFile',
+    help: 'Save the Disassembly in the give file.'
 });
 parser.addArgument('source', {help: 'Input .asm file'})
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,12 +97,12 @@ function compile(args: any) {
 
     if (args.disasm || args.disasmFile) {
         let fd: number;
-        try{
-            console.log(`Generating ${args.disasmFile}`)
+        try {
             const { isInstruction } = debugInfo!.info();
             const disasm = disassemble(prg, { isInstruction });
 
             if (args.disasmFile) {
+                console.log(`Generating ${args.disasmFile}`)
                 fd = fs.openSync(args.disasmFile, 'w');
                 for (const disasmLine of disasm) {
                     fs.writeSync(fd, `${disasmLine}\n`);
@@ -128,7 +128,7 @@ const parser = new ArgumentParser({
     version,
     addHelp: true,
     prog: 'c64jasm',
-    description: 'C64 macro assembler'
+    description: 'C64 macro assembler - fork by Shazz/TRSi'
 });
 
 parser.addArgument('--verbose', {
@@ -166,7 +166,7 @@ parser.addArgument('--disasm', {
 });
 parser.addArgument('--disasm-file', {
     dest: 'disasmFile',
-    help: 'Save the Disassembly in the give file.'
+    help: 'Save the disassembly in the given file.'
 });
 parser.addArgument('source', {help: 'Input .asm file'})
 


### PR DESCRIPTION
Hi,

This is a little patch to the CLI to, in addition to `stdout`, output the disassembly in a given file:

````
c64jasm sprites.asm --out sprites.prg --disasm-file debug.asm
c64jasm sprites.asm --out sprites.prg --disasm
````
