### PR TITLE
added label support in disassembly (see issue #71)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,13 +95,30 @@ function compile(args: any) {
         }
     }
 
-    if (args.disasm) {
-        const { isInstruction } = debugInfo!.info();
-        const disasm = disassemble(prg, { isInstruction });
-        for (const disasmLine of disasm) {
-            console.log(disasmLine);
+    if (args.disasm || args.disasmFile) {
+        let fd: number;
+        try {
+            const { isInstruction } = debugInfo!.info();
+            const disasm = disassemble(prg, labels, { isInstruction });
+
+            if (args.disasmFile) {
+                console.log(`Generating ${args.disasmFile}`)
+                fd = fs.openSync(args.disasmFile, 'w');
+                for (const disasmLine of disasm) {
+                    fs.writeSync(fd, `${disasmLine}\n`);
+                }
+            } else {
+                for (const disasmLine of disasm) {
+                    console.log(disasmLine);   
+                }
+            }
+
+
+        } catch(err) {
+            console.error(err);
         }
     }
+
     return true;
 }
 
@@ -111,7 +128,7 @@ const parser = new ArgumentParser({
     version,
     addHelp: true,
     prog: 'c64jasm',
-    description: 'C64 macro assembler'
+    description: 'C64 macro assembler - fork by Shazz/TRSi'
 });
 
 parser.addArgument('--verbose', {
@@ -146,6 +163,10 @@ parser.addArgument('--disasm', {
     constant: true,
     dest: 'disasm',
     help: 'Disassemble the resulting binary on stdout.'
+});
+parser.addArgument('--disasm-file', {
+    dest: 'disasmFile',
+    help: 'Save the disassembly in the given file.'
 });
 parser.addArgument('source', {help: 'Input .asm file'})
 

--- a/src/disasm.ts
+++ b/src/disasm.ts
@@ -50,6 +50,26 @@ class Disassembler {
     private outputPadChars = '     ';
     private outputBytesPerLine = 1;
 
+    private cycle_counts = [
+        // 0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+           7, 6, 2, 8, 3, 3, 5, 5, 3, 2, 2, 2, 4, 4, 6, 6, // 0
+           2, 5, 2, 8, 4, 4, 6, 6, 2, 4, 2, 7, 4, 4, 7, 7, // 1
+           6, 6, 2, 8, 3, 3, 5, 5, 4, 2, 2, 2, 4, 4, 6, 6, // 2
+           2, 5, 2, 8, 4, 4, 6, 6, 2, 4, 2, 7, 4, 4, 7, 7, // 3
+           6, 6, 2, 8, 3, 3, 5, 5, 3, 2, 2, 2, 3, 4, 6, 6, // 4
+           2, 5, 2, 8, 4, 4, 6, 6, 2, 4, 2, 7, 4, 4, 7, 7, // 5
+           6, 6, 2, 8, 3, 3, 5, 5, 4, 2, 2, 2, 5, 4, 6, 6, // 6
+           2, 5, 2, 8, 4, 4, 6, 6, 2, 4, 2, 7, 4, 4, 7, 7, // 7
+           2, 6, 2, 6, 3, 3, 3, 3, 2, 2, 2, 2, 4, 4, 4, 4, // 8
+           2, 6, 2, 6, 4, 4, 4, 4, 2, 5, 2, 5, 5, 5, 5, 5, // 9
+           2, 6, 2, 6, 3, 3, 3, 3, 2, 2, 2, 2, 4, 4, 4, 4, // A
+           2, 5, 2, 5, 4, 4, 4, 4, 2, 4, 2, 4, 4, 4, 4, 4, // B
+           2, 6, 2, 8, 3, 3, 5, 5, 2, 2, 2, 2, 4, 4, 6, 6, // C
+           2, 5, 2, 8, 4, 4, 6, 6, 2, 4, 2, 7, 4, 4, 7, 7, // D
+           2, 6, 2, 8, 3, 3, 5, 5, 2, 2, 2, 2, 4, 4, 6, 6, // E
+           2, 5, 2, 8, 4, 4, 6, 6, 2, 4, 2, 7, 4, 4, 7, 7  // F
+        ];
+
     private bytes: {
         startPC: number,
         bytes: number[]
@@ -67,7 +87,7 @@ class Disassembler {
         this.labels = labels;
 
         if (this.disasmOptions && this.disasmOptions.isInstruction) {
-            this.outputPadChars = '                    ';
+            this.outputPadChars = '                                                ';
             this.outputBytesPerLine = 8;
         }
 
@@ -107,90 +127,100 @@ class Disassembler {
         this.bytes.bytes = [];
     }
 
-    print = (addr: number, bytes: number[], decoded: string, label: string) => {
+    mem_read(address: number) {
+        console.log("read address", address);
+        const b = this.buf.readUInt8(address - 2061);
+        return b;
+    }
+    
+    mem_write(address: number, value: number) {
+        console.log("write address", address);
+    }
+
+    print = (addr: number, bytes: number[], decoded: string, label: string, nb_cycle: number) => {
         this.flushBytes();
         const b0 = toHex8(bytes[0]);
         const b1 = bytes.length >= 2 ? toHex8(bytes[1]) : '  ';
         const b2 = bytes.length >= 3 ? toHex8(bytes[2]) : '  ';
         const padChars = this.outputPadChars.substring(0, this.outputPadChars.length - label.length);
-        this.output.push(`${toHex16(addr)}: ${b0} ${b1} ${b2} ${label} ${padChars}${decoded}`)
+        this.output.push(`${toHex16(addr)}: ${b0} ${b1} ${b2} ${label} ${padChars}${decoded}\t; #${nb_cycle}`)
     }
 
-    disImm(mnemonic: string, op: number, label: string) {
+    disImm(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const imm = this.byte();
-        this.print(addr, [op, imm], `${mnemonic} #$${toHex8(imm)}`, label)
+        this.print(addr, [op, imm], `${mnemonic} #$${toHex8(imm)}`, label, nb_cycle)
     }
 
-    disZp(mnemonic: string, op: number, label: string) {
+    disZp(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const zp = this.byte();
-        this.print(addr, [op, zp], `${mnemonic} $${toHex8(zp)}`, label)
+        this.print(addr, [op, zp], `${mnemonic} $${toHex8(zp)}`, label, nb_cycle)
     }
 
-    disZpX(mnemonic: string, op: number, label: string) {
+    disZpX(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const zp = this.byte();
-        this.print(addr, [op, zp], `${mnemonic} $${toHex8(zp)},X`, label)
+        this.print(addr, [op, zp], `${mnemonic} $${toHex8(zp)},X`, label, nb_cycle)
     }
 
-    disZpY(mnemonic: string, op: number, label: string) {
+    disZpY(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const zp = this.byte();
-        this.print(addr, [op, zp], `${mnemonic} $${toHex8(zp)},Y`, label)
+        this.print(addr, [op, zp], `${mnemonic} $${toHex8(zp)},Y`, label, nb_cycle)
     }
 
-    disAbs(mnemonic: string, op: number, label: string) {
+    disAbs(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const lo = this.byte();
         const hi = this.byte();
-        this.print(addr, [op, lo, hi], `${mnemonic} $${toHex16(lo + hi*256)}`, label)
+        this.print(addr, [op, lo, hi], `${mnemonic} $${toHex16(lo + hi*256)}`, label, nb_cycle)
     }
 
-    disAbsX(mnemonic: string, op: number, label: string) {
+    disAbsX(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const lo = this.byte();
         const hi = this.byte();
-        this.print(addr, [op, lo, hi], `${mnemonic} $${toHex16(lo + hi*256)},X`, label)
+        this.print(addr, [op, lo, hi], `${mnemonic} $${toHex16(lo + hi*256)},X`, label, nb_cycle)
     }
 
-    disAbsY(mnemonic: string, op: number, label: string) {
+    disAbsY(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const lo = this.byte();
         const hi = this.byte();
-        this.print(addr, [op, lo, hi], `${mnemonic} $${toHex16(lo + hi*256)},Y`, label)
+        this.print(addr, [op, lo, hi], `${mnemonic} $${toHex16(lo + hi*256)},Y`, label, nb_cycle)
     }
 
-    disInd(mnemonic: string, op: number, label: string) {
+    disInd(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const lo = this.byte();
         const hi = this.byte();
-        this.print(addr, [op, lo, hi], `${mnemonic} ($${toHex16(lo + hi*256)})`, label)
+        this.print(addr, [op, lo, hi], `${mnemonic} ($${toHex16(lo + hi*256)})`, label, nb_cycle)
     }
 
-    disIndX(mnemonic: string, op: number, label: string) {
+    disIndX(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const lo = this.byte();
-        this.print(addr, [op, lo], `${mnemonic} ($${toHex8(lo)},X)`, label)
+        this.print(addr, [op, lo], `${mnemonic} ($${toHex8(lo)},X)`, label, nb_cycle)
     }
 
-    disIndY (mnemonic: string, op: number, label: string) {
+    disIndY (mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const lo = this.byte();
-        this.print(addr, [op, lo], `${mnemonic} ($${toHex8(lo)}),Y`, label)
+        this.print(addr, [op, lo], `${mnemonic} ($${toHex8(lo)}),Y`, label, nb_cycle)
     }
 
-    disSingle(mnemonic: string, op: number, label: string) {
+    disSingle(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
-        this.print(addr, [op], `${mnemonic}`, label)
+        this.print(addr, [op], `${mnemonic}`, label, nb_cycle)
     }
 
-    disBranch(mnemonic: string, op: number, label: string) {
+    disBranch(mnemonic: string, op: number, label: string, nb_cycle: number) {
         const addr = this.curAddr;
         const lo = this.byte();
         const bofs = lo >= 128 ? -(256-lo) : lo
         const tgt = addr + bofs + 2;
-        this.print(addr, [op, lo], `${mnemonic} $${toHex16(tgt)}`, label)
+        this.print(addr, [op, lo], `${mnemonic} $${toHex16(tgt)}`, label, nb_cycle)
     }
 
     disUnknown(op: number) {
@@ -223,54 +253,56 @@ class Disassembler {
             const op = this.byte()
             const decl = this.opToDecl[op];
 
+            const nb_cycle = this.cycle_counts[op];
+
             if (isInsn(this.curAddr) && decl !== undefined) {
                 const decoderIdx = decl.decode.indexOf(op);
                 if (decoderIdx === 0) {
-                    this.disImm(decl.mnemonic, op, label);
+                    this.disImm(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 1) {
-                    this.disZp(decl.mnemonic, op, label);
+                    this.disZp(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 2) {
-                    this.disZpX(decl.mnemonic, op, label);
+                    this.disZpX(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 3) {
-                    this.disZpY(decl.mnemonic, op, label);
+                    this.disZpY(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 4) {
-                    this.disAbs(decl.mnemonic, op, label);
+                    this.disAbs(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 5) {
-                    this.disAbsX(decl.mnemonic, op, label);
+                    this.disAbsX(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 6) {
-                    this.disAbsY(decl.mnemonic, op, label);
+                    this.disAbsY(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 7) {
-                    this.disInd(decl.mnemonic, op, label);
+                    this.disInd(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 8) {
-                    this.disIndX(decl.mnemonic, op, label);
+                    this.disIndX(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 9) {
-                    this.disIndY(decl.mnemonic, op, label);
+                    this.disIndY(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 10) {
-                    this.disSingle(decl.mnemonic, op, label);
+                    this.disSingle(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
                 if (decoderIdx === 11) {
-                    this.disBranch(decl.mnemonic, op, label);
+                    this.disBranch(decl.mnemonic, op, label, nb_cycle);
                     continue;
                 }
             } else {


### PR DESCRIPTION
I never coded anything with Typescript so probably not the best way to do but at least it works.
You'll tell me what to change :)

Basically what it does:
 - I added an Interface for labels in the disassembler:
````javascript
interface ILabel {
    name: string, 
    addr: number, 
    size: number
 }
````

 - The CLI provides the labels generated by the assembler to the disassembler:
````javascript
const disasm = disassemble(prg, labels, { isInstruction });
...
export function disassemble(prg: Buffer, labels?: ILabel[], options?: DisasmOptions) {
    let disasm = new Disassembler(prg, labels, options);
    return disasm.disassemble();
}
```` 

 - The disassembler convert the list of labels into a dictionary in the constructor:
````javascript
        if (this.labels) {
            this.labels.forEach(({name, addr, size}) => {
                this.labels_dict[addr] = name
            })
        }
````

 - During the disassembler process `disassemble()`, if for the given address a label exist in the dictionnary, it will be used by each decoder to generate the output:
````javascript
    print = (addr: number, bytes: number[], decoded: string, label: string) => {
        this.flushBytes();
        const b0 = toHex8(bytes[0]);
        const b1 = bytes.length >= 2 ? toHex8(bytes[1]) : '  ';
        const b2 = bytes.length >= 3 ? toHex8(bytes[2]) : '  ';
        const padChars = this.outputPadChars.substring(0, this.outputPadChars.length - label.length);
        this.output.push(`${toHex16(addr)}: ${b0} ${b1} ${b2} ${label} ${padChars}${decoded}`)
    }
````

Execution example:
````
node cli.js ../../examples/sprites/sprites.asm --out ../../dummy.prg --disasm
Compiling ../../examples/sprites/sprites.asm
Compilation succeeded.  Output written to ../../dummy.prg
0801: 0C 08 00 00 9E 32 30 36
0809: 31 00 00 00
080D: 20 8C 08 frame_loop           JSR $088C
0810: A9 00                         LDA #$00
0812: A8                            TAY
0813: 85 20                         STA $20
0815: AD 9B 08 anim_sprites         LDA $089B
0818: 18                            CLC
0819: 65 20                         ADC $20
081B: 29 3F                         AND #$3F
081D: AA                            TAX
081E: BD AC 08                      LDA $08AC,X
0821: 18                            CLC
0822: 69 64                         ADC #$64
0824: 99 9C 08                      STA $089C,Y
0827: A5 20                         LDA $20
0829: 18                            CLC
082A: 69 05                         ADC #$05
082C: 85 20                         STA $20
082E: C8                            INY
082F: C0 08                         CPY #$08
0831: D0 E2                         BNE $0815
0833: EE 9B 08                      INC $089B
0836: 20 3C 08                      JSR $083C
0839: 4C 0D 08                      JMP $080D
083C: A9 00    set_sprites          LDA #$00
083E: 8D 1D D0                      STA $D01D
0841: 8D 17 D0                      STA $D017
0844: 8D 1C D0                      STA $D01C
0847: A9 24                         LDA #$24
0849: 8D F8 07                      STA $07F8
084C: 8D F9 07                      STA $07F9
084F: 8D FA 07                      STA $07FA
0852: 8D FB 07                      STA $07FB
0855: 8D FC 07                      STA $07FC
0858: 8D FD 07                      STA $07FD
085B: 8D FE 07                      STA $07FE
085E: 8D FF 07                      STA $07FF
0861: A9 1E                         LDA #$1E
0863: 85 20                         STA $20
0865: A2 00                         LDX #$00
0867: A0 00                         LDY #$00
0869: A5 20    set_sprites::xloop   LDA $20
086B: 9D 00 D0                      STA $D000,X
````

